### PR TITLE
Changed Router Routes to Pass Props

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -9,3 +9,12 @@
     color: rgb(255, 255, 255);
     background-color: rgb(0, 157, 255);
 }
+
+.container {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.item {
+    flex-basis: 12rem;
+}

--- a/app/javascript/react/components/App.js
+++ b/app/javascript/react/components/App.js
@@ -1,12 +1,17 @@
 import React from 'react'
 import { Route, Switch, BrowserRouter } from 'react-router-dom'
 import PromptsIndexContainer from './Prompts/PromptsIndexContainer'
+import FullPage from './FullPage'
 
 const App = (props) => {
   return (
     <BrowserRouter>
       <Switch>
-        <Route exact path='/' component={PromptsIndexContainer} />
+        <Route exact path='/' render={() => 
+          <FullPage 
+            page={<PromptsIndexContainer />}
+            user={<h1>Wow</h1>}
+          />}/>
         <Route exact path='/prompts' component={PromptsIndexContainer} />
       </Switch>
     </BrowserRouter>

--- a/app/javascript/react/components/FullPage.js
+++ b/app/javascript/react/components/FullPage.js
@@ -1,0 +1,18 @@
+import React from "react";
+import PromptsIndexContainer from "./Prompts/PromptsIndexContainer";
+
+const FullPage = (props) => {
+
+    return (
+        <div className="grid-x full-page">
+            <div className="cell medium-8">
+                {props.page}
+            </div>
+            <div className="cell medium-4">
+                {props.user}
+            </div>
+        </div>
+    )
+}
+
+export default FullPage

--- a/app/javascript/react/components/Prompts/PromptIndexTile.js
+++ b/app/javascript/react/components/Prompts/PromptIndexTile.js
@@ -3,7 +3,7 @@ import React from "react";
 const PromptIndexTile = (props) => {
     const { prompt } = props
     return (
-        <div className="cell small-3 card prompt-tile">
+        <div className="item card prompt-tile">
             <div className="card-divider">
                 <h1>{prompt.title}</h1>
             </div>

--- a/app/javascript/react/components/Prompts/PromptsIndexContainer.js
+++ b/app/javascript/react/components/Prompts/PromptsIndexContainer.js
@@ -34,7 +34,7 @@ const PromptsIndexContainer = (props) => {
         })
     
     return (
-        <div className="grid-x">
+        <div className="container">
             {promptsIndex}
         </div>
     )

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,3 +10,27 @@ prompt_3 = Prompt.find_or_create_by(
     title: 'Robo-Madness',
     body: 'Advancements in tech have brought about a new form of mania: Robo-Madness...'
 )
+prompt_4 = Prompt.find_or_create_by(
+    title: 'Lovely Time',
+    body: 'A pair of best friends realize they have feelings for one another...'
+)
+prompt_5 = Prompt.find_or_create_by(
+    title: 'Look at This',
+    body: 'A family that moves into an old house finds something hidden under the floorboards...'
+)
+prompt_6 = Prompt.find_or_create_by(
+    title: 'Me Too',
+    body: 'To children talk about their favorite treats...'
+)
+prompt_7 = Prompt.find_or_create_by(
+    title: 'Ghoulish Beast',
+    body: 'A monster attacks a small village at the edge of a forest...'
+)
+prompt_8 = Prompt.find_or_create_by(
+    title: 'One Last Time',
+    body: 'An elderly man enjoys one of his childhood hobbies...'
+)
+prompt_9 = Prompt.find_or_create_by(
+    title: 'The End',
+    body: 'A man finishes telling a story, leaving the audience terrified...'
+)


### PR DESCRIPTION
Decided to try out an idea where the app comp is routing to a full page comp which is passed the prop of whatever comp I would normally use as a router comp. The point of this being that I can have the right fourth of the screen for a user block.